### PR TITLE
Add science_to_internal_fields method for reorder()

### DIFF
--- a/sparcl/__init__.py
+++ b/sparcl/__init__.py
@@ -31,4 +31,4 @@ __all__ = ["client"]
 #__version__ = '1.1rc1'
 #__version__ = '1.1rc2'
 #__version__ = '1.1'
-__version__ = '1.2.0b3.dev6'
+__version__ = '1.2.0b3.dev8'

--- a/sparcl/client.py
+++ b/sparcl/client.py
@@ -220,7 +220,7 @@ class SparclClient():  # was SparclApi()
         Example:
             >>> client = SparclClient()
             >>> client.get_default_fields()
-            ['flux', 'sparcl_id', 'wavelength']
+            ['flux', 'id', 'wavelength']
         """
 
         if dataset_list is None:
@@ -250,7 +250,7 @@ class SparclClient():  # was SparclApi()
         Example:
             >>> client = SparclClient()
             >>> client.get_all_fields()
-            ['data_release', 'datasetgroup', 'dateobs', 'dateobs_center', 'dec', 'exptime', 'fiberid', 'flux', 'sparcl_id', 'instrument', 'ivar', 'mask', 'mjd', 'model', 'plate', 'ra', 'redshift', 'redshift_err', 'redshift_warning', 'run1d', 'run2d', 'site', 'sky', 'specid', 'specobjid', 'specprimary', 'spectype', 'targetid', 'telescope', 'wave_sigma', 'wavelength', 'wavemax', 'wavemin']
+            ['data_release', 'datasetgroup', 'dateobs', 'dateobs_center', 'dec', 'exptime', 'fiberid', 'flux', 'id', 'instrument', 'ivar', 'mask', 'mjd', 'model', 'plate', 'ra', 'redshift', 'redshift_err', 'redshift_warning', 'run1d', 'run2d', 'site', 'sky', 'specid', 'specobjid', 'specprimary', 'spectype', 'targetid', 'telescope', 'wave_sigma', 'wavelength', 'wavemax', 'wavemin']
     """
 
         common = set(self.fields.common(dataset_list))
@@ -305,7 +305,7 @@ class SparclClient():  # was SparclApi()
         Example:
             >>> client = SparclClient()
             >>> sorted(client.get_available_fields())
-            ['data_release', 'datasetgroup', 'dateobs', 'dateobs_center', 'dec', 'dirpath', 'exptime', 'extra_files', 'fiberid', 'filename', 'filesize', 'flux', 'sparcl_id', 'instrument', 'ivar', 'mask', 'mjd', 'model', 'plate', 'ra', 'redshift', 'redshift_err', 'redshift_warning', 'run1d', 'run2d', 'site', 'sky', 'specid', 'specobjid', 'specprimary', 'spectype', 'targetid', 'telescope', 'updated', 'wave_sigma', 'wavelength', 'wavemax', 'wavemin']
+            ['data_release', 'datasetgroup', 'dateobs', 'dateobs_center', 'dec', 'dirpath', 'exptime', 'extra_files', 'fiberid', 'filename', 'filesize', 'flux', 'id', 'instrument', 'ivar', 'mask', 'mjd', 'model', 'plate', 'ra', 'redshift', 'redshift_err', 'redshift_warning', 'run1d', 'run2d', 'site', 'sky', 'specid', 'specobjid', 'specprimary', 'spectype', 'targetid', 'telescope', 'updated', 'wave_sigma', 'wavelength', 'wavemax', 'wavemin']
         """
 
         drs = self.fields.all_drs if dataset_list is None else dataset_list
@@ -366,11 +366,11 @@ class SparclClient():  # was SparclApi()
 
         Example:
             >>> client = SparclClient()
-            >>> outs = ['sparcl_id', 'ra', 'dec']
+            >>> outs = ['id', 'ra', 'dec']
             >>> cons = {'spectype': ['GALAXY'], 'redshift': [0.5, 0.9]}
             >>> found = client.find(outfields=outs, constraints=cons)
             >>> sorted(list(found.records[0].keys()))
-            ['_dr', 'dec', 'sparcl_id', 'ra']
+            ['_dr', 'dec', 'id', 'ra']
         """
         # dataset_list (:obj:`list`, optional): List of data sets from
         #     which to find records. Defaults to None, which
@@ -533,7 +533,7 @@ class SparclClient():  # was SparclApi()
         Example:
             >>> client = SparclClient()
             >>> ids = ['000017b6-56a2-4f87-8828-3a3409ba1083',]
-            >>> inc = ['sparcl_id', 'flux', 'wavelength', 'model']
+            >>> inc = ['id', 'flux', 'wavelength', 'model']
             >>> ret = client.retrieve(uuid_list=ids, include=inc)
             >>> type(ret.records[0].wavelength)
             <class 'numpy.ndarray'>

--- a/sparcl/client.py
+++ b/sparcl/client.py
@@ -251,7 +251,7 @@ class SparclClient():  # was SparclApi()
             >>> client = SparclClient()
             >>> client.get_all_fields()
             ['data_release', 'datasetgroup', 'dateobs', 'dateobs_center', 'dec', 'exptime', 'fiberid', 'flux', 'id', 'instrument', 'ivar', 'mask', 'mjd', 'model', 'plate', 'ra', 'redshift', 'redshift_err', 'redshift_warning', 'run1d', 'run2d', 'site', 'sky', 'specid', 'specobjid', 'specprimary', 'spectype', 'targetid', 'telescope', 'wave_sigma', 'wavelength', 'wavemax', 'wavemin']
-    """
+    """  # noqa: E501
 
         common = set(self.fields.common(dataset_list))
         union = self.fields.all_retrieve_fields(dataset_list=dataset_list)
@@ -306,7 +306,7 @@ class SparclClient():  # was SparclApi()
             >>> client = SparclClient()
             >>> sorted(client.get_available_fields())
             ['data_release', 'datasetgroup', 'dateobs', 'dateobs_center', 'dec', 'dirpath', 'exptime', 'extra_files', 'fiberid', 'filename', 'filesize', 'flux', 'id', 'instrument', 'ivar', 'mask', 'mjd', 'model', 'plate', 'ra', 'redshift', 'redshift_err', 'redshift_warning', 'run1d', 'run2d', 'site', 'sky', 'specid', 'specobjid', 'specprimary', 'spectype', 'targetid', 'telescope', 'updated', 'wave_sigma', 'wavelength', 'wavemax', 'wavemin']
-        """
+        """  # noqa: E501
 
         drs = self.fields.all_drs if dataset_list is None else dataset_list
         every = [set(self.fields.n2o[dr]) for dr in drs]

--- a/sparcl/client.py
+++ b/sparcl/client.py
@@ -220,7 +220,7 @@ class SparclClient():  # was SparclApi()
         Example:
             >>> client = SparclClient()
             >>> client.get_default_fields()
-            ['flux', 'id', 'wavelength']
+            ['flux', 'sparcl_id', 'wavelength']
         """
 
         if dataset_list is None:
@@ -250,7 +250,7 @@ class SparclClient():  # was SparclApi()
         Example:
             >>> client = SparclClient()
             >>> client.get_all_fields()
-            ['data_release', 'datasetgroup', 'dateobs', 'dateobs_center', 'dec', 'exptime', 'fiberid', 'flux', 'id', 'instrument', 'ivar', 'mask', 'mjd', 'model', 'plate', 'ra', 'redshift', 'redshift_err', 'redshift_warning', 'run1d', 'run2d', 'site', 'sky', 'specid', 'specobjid', 'specprimary', 'spectype', 'targetid', 'telescope', 'wave_sigma', 'wavelength', 'wavemax', 'wavemin']
+            ['data_release', 'datasetgroup', 'dateobs', 'dateobs_center', 'dec', 'exptime', 'fiberid', 'flux', 'sparcl_id', 'instrument', 'ivar', 'mask', 'mjd', 'model', 'plate', 'ra', 'redshift', 'redshift_err', 'redshift_warning', 'run1d', 'run2d', 'site', 'sky', 'specid', 'specobjid', 'specprimary', 'spectype', 'targetid', 'telescope', 'wave_sigma', 'wavelength', 'wavemax', 'wavemin']
     """
 
         common = set(self.fields.common(dataset_list))
@@ -305,7 +305,7 @@ class SparclClient():  # was SparclApi()
         Example:
             >>> client = SparclClient()
             >>> sorted(client.get_available_fields())
-            ['data_release', 'datasetgroup', 'dateobs', 'dateobs_center', 'dec', 'dirpath', 'exptime', 'extra_files', 'fiberid', 'filename', 'filesize', 'flux', 'id', 'instrument', 'ivar', 'mask', 'mjd', 'model', 'plate', 'ra', 'redshift', 'redshift_err', 'redshift_warning', 'run1d', 'run2d', 'site', 'sky', 'specid', 'specobjid', 'specprimary', 'spectype', 'targetid', 'telescope', 'updated', 'wave_sigma', 'wavelength', 'wavemax', 'wavemin']
+            ['data_release', 'datasetgroup', 'dateobs', 'dateobs_center', 'dec', 'dirpath', 'exptime', 'extra_files', 'fiberid', 'filename', 'filesize', 'flux', 'sparcl_id', 'instrument', 'ivar', 'mask', 'mjd', 'model', 'plate', 'ra', 'redshift', 'redshift_err', 'redshift_warning', 'run1d', 'run2d', 'site', 'sky', 'specid', 'specobjid', 'specprimary', 'spectype', 'targetid', 'telescope', 'updated', 'wave_sigma', 'wavelength', 'wavemax', 'wavemin']
         """
 
         drs = self.fields.all_drs if dataset_list is None else dataset_list
@@ -344,8 +344,8 @@ class SparclClient():  # was SparclApi()
         Args:
             outfields (:obj:`list`, optional): List of fields to return.
                 Only CORE fields may be passed to this parameter.
-                Defaults to None, which will return only the id and _dr
-                fields.
+                Defaults to None, which will return only the sparcl_id
+                and _dr fields.
 
             constraints (:obj:`dict`, optional): Key-Value pairs of
                 constraints to place on the record selection. The Key
@@ -366,11 +366,11 @@ class SparclClient():  # was SparclApi()
 
         Example:
             >>> client = SparclClient()
-            >>> outs = ['id', 'ra', 'dec']
+            >>> outs = ['sparcl_id', 'ra', 'dec']
             >>> cons = {'spectype': ['GALAXY'], 'redshift': [0.5, 0.9]}
             >>> found = client.find(outfields=outs, constraints=cons)
             >>> sorted(list(found.records[0].keys()))
-            ['_dr', 'dec', 'id', 'ra']
+            ['_dr', 'dec', 'sparcl_id', 'ra']
         """
         # dataset_list (:obj:`list`, optional): List of data sets from
         #     which to find records. Defaults to None, which
@@ -415,26 +415,26 @@ class SparclClient():  # was SparclApi()
 
     def missing(self, uuid_list, *, dataset_list=None,
                 countOnly=False, verbose=False):
-        """Return the subset of ids in the given uuid_list that are NOT stored
-        in the SPARC database.
+        """Return the subset of sparcl_ids in the given uuid_list that are
+        NOT stored in the SPARC database.
 
         Args:
-            uuid_list (:obj:`list`): List of ids.
+            uuid_list (:obj:`list`): List of sparcl_ids.
 
             dataset_list (:obj:`list`, optional): List of data sets from
-                which to find missing ids. Defaults to None, meaning all
-                data sets hosted on the SPARC database.
+                which to find missing sparcl_ids. Defaults to None, meaning
+                all data sets hosted on the SPARC database.
 
             countOnly (:obj:`bool`, optional): Set to True to return only
-                a count of the missing ids from the uuid_list. Defaults to
-                False.
+                a count of the missing sparcl_ids from the uuid_list.
+                Defaults to False.
 
             verbose (:obj:`bool`, optional): Set to True for in-depth return
                 statement. Defaults to False.
 
         Returns:
-            A list of the subset of ids in the given uuid_list that are NOT
-            stored in the SPARC database.
+            A list of the subset of sparcl_ids in the given uuid_list that
+            are NOT stored in the SPARC database.
 
         Example:
             >>> client = SparclClient()
@@ -500,10 +500,11 @@ class SparclClient():  # was SparclApi()
                  limit=500,
                  chunk=500,
                  verbose=None):
-        """Retrieve spectra records from the SPARC database by list of ids.
+        """Retrieve spectra records from the SPARC database by list of
+        sparcl_ids.
 
         Args:
-            uuid_list (:obj:`list`): List of ids.
+            uuid_list (:obj:`list`): List of sparcl_ids.
 
             svc (:obj:`str`, optional): Defaults to 'spectras'.
 
@@ -532,7 +533,7 @@ class SparclClient():  # was SparclApi()
         Example:
             >>> client = SparclClient()
             >>> ids = ['000017b6-56a2-4f87-8828-3a3409ba1083',]
-            >>> inc = ['id', 'flux', 'wavelength', 'model']
+            >>> inc = ['sparcl_id', 'flux', 'wavelength', 'model']
             >>> ret = client.retrieve(uuid_list=ids, include=inc)
             >>> type(ret.records[0].wavelength)
             <class 'numpy.ndarray'>
@@ -559,7 +560,7 @@ class SparclClient():  # was SparclApi()
         #!       f'  len(uuid_list)={len(uuid_list):,d}'
         #!       f'  limit={limit}'
         #!       f'  MAX_NUM_RECORDS_RETRIEVED={MAX_NUM_RECORDS_RETRIEVED:,d}')
-        if (req_num  >  MAX_NUM_RECORDS_RETRIEVED):
+        if (req_num > MAX_NUM_RECORDS_RETRIEVED):
             msg = (f'Too many records asked for with client.retrieve().'
                    f'  {len(uuid_list):,d} IDs provided,'
                    f'  limit={limit}.'

--- a/sparcl/exceptions.py
+++ b/sparcl/exceptions.py
@@ -114,6 +114,7 @@ class NoRecords(BaseSparclException):
     """Results did not contain any records"""
     error_code = 'NORECORD'
 
+
 class TooManyRecords(BaseSparclException):
     """Too many records asked for in RETRIEVE"""
     error_code = 'TOOMANYR'

--- a/tests/expected.py
+++ b/tests/expected.py
@@ -1,7 +1,7 @@
 # For PAT hosts
 
 #!idfld = 'uuid'  # Science Field Name for uuid. Diff val than Internal name.
-idfld = 'id'      # Science Field Name for uuid. Diff val than Internal name.
+idfld = 'sparcl_id'  # Sci Field Name for uuid. Diff val than Internal name.
 
 all_fields = ['data_release',
               'datasetgroup',
@@ -10,7 +10,6 @@ all_fields = ['data_release',
               'dec',
               'exptime',
               'flux',
-              'id',
               'instrument',
               'ivar',
               'mask',
@@ -22,6 +21,7 @@ all_fields = ['data_release',
               'redshift_warning',
               'site',
               'sky',
+              idfld,
               'specid',
               'specprimary',
               'spectype',
@@ -32,12 +32,12 @@ all_fields = ['data_release',
               'wavemax',
               'wavemin']
 
-default_fields = ['dec', 'flux', 'id', 'ra', 'specid', 'wavelength']
+default_fields = ['dec', 'flux', 'ra', idfld, 'specid', 'wavelength']
 
 #retrieve_0 = [1506512395860731904]
 retrieve_0 = [3383388400617889792]  # PAT
 
-retrieve_0b = ['_dr', 'dec', 'flux', idfld, 'ra', 'specid', 'wavelength']
+retrieve_0b = ['_dr', 'dec', 'flux', 'ra', idfld, 'specid', 'wavelength']
 
 retrieve_4 = ['FIBERID',
               'MJD',
@@ -84,12 +84,12 @@ retrieve_4 = ['FIBERID',
 
 find_0 = [{'_dr': 'SDSS-DR16',
            'dec': 63.029566,
-           'id': '2587dc0b-296a-4f77-8197-75431d7e8773',
-           'ra': 137.74507},
+           'ra': 137.74507,
+           'sparcl_id': '2587dc0b-296a-4f77-8197-75431d7e8773'},
           {'_dr': 'SDSS-DR16',
            'dec': 63.286553,
-           'id': '26616ea2-fd26-456d-bb90-d249c597f89a',
-           'ra': 137.48823}]  # PAT
+           'ra': 137.48823,
+           'sparcl_id': '26616ea2-fd26-456d-bb90-d249c597f89a'}]  # PAT
 
 #find_1 = [{'_dr': 'SDSS-DR16',
 #  'dec': 35.039381,
@@ -98,8 +98,8 @@ find_0 = [{'_dr': 'SDSS-DR16',
 
 find_1 = [{'_dr': 'BOSS-DR16',
            'dec': 44.143862,
-           'id': '00000ce3-d15b-4ef5-952b-5790e96af5d7',
-           'ra': 194.55856}]
+           'ra': 194.55856,
+           'sparcl_id': '00000ce3-d15b-4ef5-952b-5790e96af5d7'}]
 
 #find_2 = 640  # DEV
 find_2 = 936894  # PAT
@@ -119,16 +119,16 @@ find_2 = 936894  # PAT
 
 find_3 = [{'_dr': 'BOSS-DR16',
            'dec': 44.143862,
-           'id': '00000ce3-d15b-4ef5-952b-5790e96af5d7',
-           'ra': 194.55856},
+           'ra': 194.55856,
+           'sparcl_id': '00000ce3-d15b-4ef5-952b-5790e96af5d7'},
           {'_dr': 'DESI-EDR',
            'dec': 32.9667091540768,
-           'id': '00001c4b-c0b7-4098-bb85-59f37b81af93',
-           'ra': 141.861318540722},
+           'ra': 141.861318540722,
+           'sparcl_id': '00001c4b-c0b7-4098-bb85-59f37b81af93'},
           {'_dr': 'BOSS-DR16',
            'dec': 21.33438,
-           'id': '00001f94-96b1-4f2d-8d1d-1a47a89fe105',
-           'ra': 0.863617040000008}]
+           'ra': 0.863617040000008,
+           'sparcl_id': '00001f94-96b1-4f2d-8d1d-1a47a89fe105'}]
 
 find_4 = ['00000ce3-d15b-4ef5-952b-5790e96af5d7',
           '00001c4b-c0b7-4098-bb85-59f37b81af93',

--- a/tests/tests_api.py
+++ b/tests/tests_api.py
@@ -49,15 +49,17 @@ else:
 
 
 #!idfld = 'uuid'  # Science Field Name for uuid. Diff val than Internal name.
-idfld = 'id'      # Science Field Name for uuid. Diff val than Internal name.
+idfld = 'sparcl_id'  # Sci Field Name for uuid. Diff val than Internal name.
 
 showact = False
 #showact = True
 showact = showact or os.environ.get('showres') == '1'
 
+
 def load_tests(loader, tests, ignore):
     tests.addTests(doctest.DocTestSuite(sparcl.client))
     return tests
+
 
 class SparclClientTest(unittest.TestCase):
     """Test access to each endpoint of the Server API"""
@@ -307,7 +309,7 @@ class SparclClientTest(unittest.TestCase):
                          msg='Actual to Expected')
 
     def test_reorder_1a(self):
-        """Reorder retrieved records by ID."""
+        """Reorder retrieved records by sparcl_id."""
         name = 'reorder_1a'
         ids = self.uuids2
 
@@ -315,7 +317,7 @@ class SparclClientTest(unittest.TestCase):
         res = self.client.retrieve(ids)
         self.timing[name] = toc()
         res_reorder = res.reorder(ids)
-        actual = [f['id'] for f in res_reorder.records]
+        actual = [f['sparcl_id'] for f in res_reorder.records]
         if showact:
             print(f'reorder_1a: actual={pf(actual)}')
         self.assertEqual(actual,
@@ -339,7 +341,7 @@ class SparclClientTest(unittest.TestCase):
                          msg='Actual to Expected')
 
     def test_reorder_2a(self):
-        """Reorder records when ID is missing from database, after using
+        """Reorder records when sparcl_id is missing from database, after using
            retrieve()."""
         name = 'reorder_2a'
         ids = self.uuids3
@@ -350,7 +352,7 @@ class SparclClientTest(unittest.TestCase):
         self.timing[name] = toc()
         with self.assertWarns(Warning):
             res_reorder = res.reorder(ids)
-        actual = [f['id'] for f in res_reorder.records]
+        actual = [f['sparcl_id'] for f in res_reorder.records]
         if showact:
             print(f'reorder_2a: actual={pf(actual)}')
         self.assertEqual(actual,
@@ -376,8 +378,8 @@ class SparclClientTest(unittest.TestCase):
                          msg='Actual to Expected')
 
     def test_reorder_3a(self):
-        """Test for expected Exception when a list of IDs with length 0 is
-           passed to reorder method after using retrieve()."""
+        """Test for expected Exception when a list of sparcl_ids with
+           length 0 is passed to reorder method after using retrieve()."""
         name = 'reorder_3a'
         ids = self.uuids2
         og_ids = []
@@ -402,8 +404,8 @@ class SparclClientTest(unittest.TestCase):
             res.reorder(og_specids)
 
     def test_reorder_4a(self):
-        """Test for expected Exception when there are no records, using IDs
-           and retrieve()."""
+        """Test for expected Exception when there are no records, using
+           sparcl_ids and retrieve()."""
         name = 'reorder_4a'
         ids = self.uuids4
 


### PR DESCRIPTION
All tests pass on sparcdev2 as devops in /home/ajacques/sparclclient:
```
(venv) [devops@sparcdev2 sparclclient]$ python -m unittest tests.tests_api
Running Client tests
         against Server: "sparc1.datalab.noirlab.edu"
         comparing to <module 'tests.expected' from '/home/ajacques/sparclclient/tests/expected.py'>

..s...........................
----------------------------------------------------------------------
Ran 30 tests in 4.317s

OK (skipped=1)
```

flake8 also passes.