### PR TITLE
Add warning message about skipped authtests

### DIFF
--- a/tests/tests_api.py
+++ b/tests/tests_api.py
@@ -34,7 +34,7 @@
 # Python library
 from contextlib import contextmanager
 import unittest
-from unittest import skip, skipUnless
+from unittest import skip, skipUnless, skipIf
 import datetime
 
 #! from unittest mock, skipIf, skipUnless
@@ -687,6 +687,13 @@ class AlignRecordsTest(unittest.TestCase):
         with self.assertRaises(Exception, msg=msg):
             ar_dict, grid = sg.align_records(got.records, precision=11)
             # shape = ar_dict['flux'].shape
+
+@skipIf('usrpw' in os.environ, 'Ran with usrpw provided')
+class NoopTest(unittest.TestCase):
+    """Non-tests."""
+
+    def test_noop(self):
+        print('<Skipped-AuthTest>', end='', flush=True)
 
 @skipUnless('usrpw' in os.environ, 'Password is required to test auth')
 class AuthTest(unittest.TestCase):


### PR DESCRIPTION
When no usrpw variable is passed to the client tests command, the warning message `<Skipped-AuthTest>` will appear in the output:

```
(venv) [devops@sparc1 sparclclient]$ python -m unittest tests.tests_api
ssssssssssssssssssssssss<Skipped-AuthTest>.Running Client tests
  against Server: "sparc1.datalab.noirlab.edu"
  comparing to: tests.expected_pat
  showact=False
  showcurl=False
  client=(sparclclient:1.2.2b8, api:11.0, https://sparc1.datalab.noirlab.edu/sparc, client_hash=, verbose=False, connect_timeout=1.1, read_timeout=5400.0)
```