### PR TITLE
Fix client tests, update expected values

### DIFF
--- a/tests/expected_pat.py
+++ b/tests/expected_pat.py
@@ -37,7 +37,10 @@ default_fields = ["dec", "flux", "ra", "sparcl_id", "specid", "wavelength"]
 # OLD as of Dec 14, 2023
 # retrieve_0 = [1254334738051655680, 1254335012929562624]
 
-retrieve_0 = [39627920993422590, 39627926995470031]
+# OLD as of May 3, 2024
+#retrieve_0 = [39627920993422590, 39627926995470031]
+
+retrieve_0 = ["_dr", "flux", "sparcl_id", "specid"]
 
 retrieve_0b = ["_dr", "dec", "flux", "ra", "sparcl_id", "specid", "wavelength"]
 
@@ -45,7 +48,10 @@ retrieve_0b = ["_dr", "dec", "flux", "ra", "sparcl_id", "specid", "wavelength"]
 # OLD as of Dec 14, 2023
 # retrieve_5 = [1254334738051655680, 1254335012929562624]
 
-retrieve_5 = [39627920993422590, 39627926995470031]
+# OLD as of May 3, 2024
+#retrieve_5 = [39627920993422590, 39627926995470031]
+
+retrieve_5 = 2
 
 # OLD as of Dec 14, 2023
 # find_0 = [
@@ -63,21 +69,25 @@ retrieve_5 = [39627920993422590, 39627926995470031]
 #    },
 # ]
 
+# OLD as of May 3, 2024
+#find_0 = [
+#    {
+#        "_dr": "BOSS-DR16",
+#        "dec": 3.4911852,
+#        "ra": 340.93613000000005,
+#        "sparcl_id": "0c46e982-992d-11ee-b800-525400aad0aa",
+#    },
+#    {
+#        "_dr": "BOSS-DR16",
+#        "dec": 3.0464991,
+#        "ra": 340.93298000000004,
+#        "sparcl_id": "2602c4a5-992d-11ee-b3e7-525400aad0aa",
+#    },
+#]
 
-find_0 = [
-    {
-        "_dr": "BOSS-DR16",
-        "dec": 3.4911852,
-        "ra": 340.93613000000005,
-        "sparcl_id": "0c46e982-992d-11ee-b800-525400aad0aa",
-    },
-    {
-        "_dr": "BOSS-DR16",
-        "dec": 3.0464991,
-        "ra": 340.93298000000004,
-        "sparcl_id": "2602c4a5-992d-11ee-b3e7-525400aad0aa",
-    },
-]
+find_0 = [{'_dr': 'BOSS-DR16',
+           'data_release': 'BOSS-DR16',
+           'specid': -6444642403514822656}]
 
 # OLD as of Dec 14, 2023
 # find_1 = [
@@ -89,14 +99,19 @@ find_0 = [
 #    }
 # ]
 
-find_1 = [
-    {
-        "_dr": "DESI-EDR",
-        "dec": 5.662937176455572,
-        "ra": 208.7076645721256,
-        "sparcl_id": "00063e73-992e-11ee-ad57-525400aad0aa",
-    }
-]
+# OLD as of May 3, 2024
+#find_1 = [
+#    {
+#        "_dr": "DESI-EDR",
+#        "dec": 5.662937176455572,
+#        "ra": 208.7076645721256,
+#        "sparcl_id": "00063e73-992e-11ee-ad57-525400aad0aa",
+#    }
+#]
+
+find_1 = [{'_dr': 'SDSS-DR16',
+           'data_release': 'SDSS-DR16',
+           'specid': 1506454396622366720}]
 
 find_2 = 936894  # PAT
 
@@ -136,26 +151,31 @@ find_2 = 936894  # PAT
 #           'ra': 194.86904,
 #           'sparcl_id': '000e388f-992d-11ee-a373-525400aad0aa'}]
 
-find_3 = [
-    {
-        "_dr": "DESI-EDR",
-        "dec": 5.662937176455572,
-        "ra": 208.7076645721256,
-        "sparcl_id": "00063e73-992e-11ee-ad57-525400aad0aa",
-    },
-    {
-        "_dr": "DESI-EDR",
-        "dec": 5.492057016906403,
-        "ra": 209.52823969727436,
-        "sparcl_id": "000d4892-9931-11ee-9e4d-525400aad0aa",
-    },
-    {
-        "_dr": "BOSS-DR16",
-        "dec": 27.461703,
-        "ra": 141.95067,
-        "sparcl_id": "001b11a6-992f-11ee-993c-525400aad0aa",
-    },
-]
+# OLD as of May 3, 2024
+#find_3 = [
+#    {
+#        "_dr": "DESI-EDR",
+#        "dec": 5.662937176455572,
+#        "ra": 208.7076645721256,
+#        "sparcl_id": "00063e73-992e-11ee-ad57-525400aad0aa",
+#    },
+#    {
+#        "_dr": "DESI-EDR",
+#        "dec": 5.492057016906403,
+#        "ra": 209.52823969727436,
+#        "sparcl_id": "000d4892-9931-11ee-9e4d-525400aad0aa",
+#    },
+#    {
+#        "_dr": "BOSS-DR16",
+#        "dec": 27.461703,
+#        "ra": 141.95067,
+#        "sparcl_id": "001b11a6-992f-11ee-993c-525400aad0aa",
+#    },
+#]
+
+find_3 = [{'_dr': 'BOSS-DR16', 'data_release': 'BOSS-DR16'},
+          {'_dr': 'BOSS-DR16', 'data_release': 'BOSS-DR16'},
+          {'_dr': 'BOSS-DR16', 'data_release': 'BOSS-DR16'}]
 
 # OLD as of Dec 14, 2023
 # find_4 = [
@@ -169,11 +189,14 @@ find_3 = [
 #          '000d4892-9931-11ee-9e4d-525400aad0aa',
 #          '000e388f-992d-11ee-a373-525400aad0aa']
 
-find_4 = [
-    "00063e73-992e-11ee-ad57-525400aad0aa",
-    "000d4892-9931-11ee-9e4d-525400aad0aa",
-    "001b11a6-992f-11ee-993c-525400aad0aa",
-]
+# OLD as of May 3, 2024
+#find_4 = [
+#    "00063e73-992e-11ee-ad57-525400aad0aa",
+#    "000d4892-9931-11ee-9e4d-525400aad0aa",
+#    "001b11a6-992f-11ee-993c-525400aad0aa",
+#]
+
+find_4 = 36
 
 find_5a = [
     {"_dr": "BOSS-DR16", "data_release": "BOSS-DR16", "mjd": 55689},
@@ -194,11 +217,12 @@ find_5d = []
 #              '000d4892-9931-11ee-9e4d-525400aad0aa',
 #              '000e388f-992d-11ee-a373-525400aad0aa']
 
-reorder_1a = [
-    "00063e73-992e-11ee-ad57-525400aad0aa",
-    "000d4892-9931-11ee-9e4d-525400aad0aa",
-    "001b11a6-992f-11ee-993c-525400aad0aa",
-]
+# OLD as of May 3, 2024
+#reorder_1a = [
+#    "00063e73-992e-11ee-ad57-525400aad0aa",
+#    "000d4892-9931-11ee-9e4d-525400aad0aa",
+#    "001b11a6-992f-11ee-993c-525400aad0aa",
+#]
 
 # OLD as of Dec 14, 2023
 # reorder_1b = [1254334738051655680, 1254335012929562624, 1254335287807469568]
@@ -206,21 +230,24 @@ reorder_1a = [
 # OLD as of March 13, 2024
 # reorder_1b = [39627926995470031, 39627920993422590, 2258670445286942720]
 
-reorder_1b = [39627926995470031, 39627920993422590, -5672180510041550848]
+# OLD as of May 3, 2024
+#reorder_1b = [39627926995470031, 39627920993422590, -5672180510041550848]
 
 # OLD as of Dec 14, 2023
 # reorder_2a = [1254334738051655680, 1254335012929562624, None]
 
-reorder_2a = [
-    "00063e73-992e-11ee-ad57-525400aad0aa",
-    "000d4892-9931-11ee-9e4d-525400aad0aa",
-    "None",
-]
+# OLD as of May 3, 2024
+#reorder_2a = [
+#    "00063e73-992e-11ee-ad57-525400aad0aa",
+#    "000d4892-9931-11ee-9e4d-525400aad0aa",
+#    "None",
+#]
 
 # OLD as of Dec 14, 2023
 # reorder_2b = [1254334738051655680, 1254335012929562624, None]
 
-reorder_2b = [39627926995470031, 39627920993422590, None]
+# OLD as of May 3, 2024
+#reorder_2b = [39627926995470031, 39627920993422590, None]
 
 authorized_1 = {
     "Loggedin_As": "test_user_1@noirlab.edu",
@@ -243,16 +270,17 @@ authorized_3 = {
 }
 
 # Private and Public
-pub = ["BOSS-DR16", "DESI-EDR", "SDSS-DR16"]
+pub_1 = ["BOSS-DR16"]
+pub_all = ["BOSS-DR16", "DESI-EDR", "SDSS-DR16"]
 priv = ["SDSS-DR17-test"]
 unauth = "test_user_2@noirlab.edu"
 #
-auth_find_1 = auth_find_2 = pub + priv
+auth_find_1 = auth_find_2 = pub_all + priv
 auth_find_3 = f"[DSDENIED] {unauth} is declined access to datasets {priv}"
-auth_find_4 = auth_find_6 = pub
+auth_find_4 = auth_find_6 = pub_all
 auth_find_5 = f"[DSDENIED] ANONYMOUS is declined access to datasets {priv}"
 #
-auth_retrieve_1 = auth_retrieve_2 = pub + priv
+auth_retrieve_1 = auth_retrieve_2 = pub_1 + priv
 auth_retrieve_3 = f"[DSDENIED] {unauth} is declined access to datasets {priv}"
-auth_retrieve_4 = auth_retrieve_5 = auth_retrieve_7 = auth_retrieve_8 = pub
+auth_retrieve_4 = auth_retrieve_5 = auth_retrieve_7 = auth_retrieve_8 = pub_1
 auth_retrieve_6 = f"[DSDENIED] ANONYMOUS is declined access to datasets {priv}"


### PR DESCRIPTION
- Reduce limit for retrieve tests to less than 24,000
- Replace any expected values that are server-dependent
- The `expected_pat.py` file now works for both DEV and PAT servers

All 64 tests pass against sparc1 server with info:
```
Running Client tests
  against Server: "sparc1.datalab.noirlab.edu"
  comparing to: tests.expected_pat
  showact=False
  showcurl=False
  cls.client=(sparclclient:1.2.2b8, api:11.0, https://sparc1.datalab.noirlab.edu/sparc, client_
hash=, verbose=False, connect_timeout=1.1, read_timeout=5400.0)
```

The Auth tests do not pass on sparcdev2 server with info:
```
Running Client tests
  against Server: "sparcdev2.csdc.noirlab.edu:8050"
  comparing to: tests.expected_pat
  showact=False
  showcurl=False
  cls.client=(sparclclient:1.2.2b8, api:11.0, http://sparcdev2.csdc.noirlab.edu:8050/sparc, client_hash=, verbose=False, connect_timeout=1.1, read_timeout=5400.0)
```
Error states that `test_user_1@noirlab.edu is declined access to datasets ['SDSS-DR17-test']`, but they SHOULD be able to access that dataset. Might be a SSO issue. Will look into more next week.
