### PR TITLE
Trim output from tests

### DIFF
--- a/tests/tests_api.py
+++ b/tests/tests_api.py
@@ -168,7 +168,7 @@ class SparclClientTest(unittest.TestCase):
         cls.count = dict()
 
         print(
-            f"Running Client tests\n"
+            f"Running Basic Client Tests\n"
             f'  against Server: "{urlparse(serverurl).netloc}"\n'
             f"  comparing to: {exp.__name__}\n"
             f"  showact={showact}\n"
@@ -621,6 +621,14 @@ class AlignRecordsTest(unittest.TestCase):
         cls.client = sparcl.client.SparclClient(
             url=serverurl, verbose=clverb, show_curl=showcurl
         )
+        print(
+            f"Running Align Records Client Tests\n"
+            f'  against Server: "{urlparse(serverurl).netloc}"\n'
+            f"  comparing to: {exp.__name__}\n"
+            f"  showact={showact}\n"
+            f"  showcurl={showcurl}\n"
+            f"  client={cls.client}\n"
+        )
         found = cls.client.find(
             constraints={"data_release": ["BOSS-DR16"]}, limit=20
         )
@@ -732,7 +740,14 @@ class AuthTest(unittest.TestCase):
         cls.client = sparcl.client.SparclClient(
             url=serverurl, verbose=clverb, show_curl=showcurl
         )
-
+        print(
+            f"Running Auth Client Tests\n"
+            f'  against Server: "{urlparse(serverurl).netloc}"\n'
+            f"  comparing to: {exp.__name__}\n"
+            f"  showact={showact}\n"
+            f"  showcurl={showcurl}\n"
+            f"  client={cls.client}\n"
+        )
         cls.outflds = ["sparcl_id", "data_release"]
         cls.inc = ["data_release", "flux"]
 

--- a/tests/tests_api.py
+++ b/tests/tests_api.py
@@ -79,7 +79,7 @@ _PAT1 = "https://sparc1.datalab.noirlab.edu"  # noqa: E221
 _STAGE = "https://sparclstage.datalab.noirlab.edu"  # noqa: E221
 _PROD = "https://astrosparcl.datalab.noirlab.edu"  # noqa: E221
 
-serverurl = os.environ.get("serverurl", _PAT1)
+serverurl = os.environ.get("serverurl", _PROD)
 #!DEV_SERVERS = [_DEV1,]
 DEV_SERVERS = []
 
@@ -104,6 +104,8 @@ if showall:
 
 usrpw = os.environ.get("usrpw")
 
+check1 = False
+check2 = True
 
 @contextmanager
 def streamhandler_to_console(lggr):
@@ -167,14 +169,19 @@ class SparclClientTest(unittest.TestCase):
         cls.doc = dict()
         cls.count = dict()
 
-        print(
-            f"Running Basic Client Tests\n"
-            f'  against Server: "{urlparse(serverurl).netloc}"\n'
-            f"  comparing to: {exp.__name__}\n"
-            f"  showact={showact}\n"
-            f"  showcurl={showcurl}\n"
-            f"  client={cls.client}\n"
-        )
+        global check1
+        global check2
+
+        if check1 is False:
+            print(
+                f"Running Client Tests\n"
+                f'  against Server: "{urlparse(serverurl).netloc}"\n'
+                f"  comparing to: {exp.__name__}\n"
+                f"  showact={showact}\n"
+                f"  showcurl={showcurl}\n"
+                f"  client={cls.client}\n"
+            )
+            check2 = False
 
         # Get some id_lists to use in tests
         found = cls.client.find(
@@ -621,14 +628,6 @@ class AlignRecordsTest(unittest.TestCase):
         cls.client = sparcl.client.SparclClient(
             url=serverurl, verbose=clverb, show_curl=showcurl
         )
-        print(
-            f"Running Align Records Client Tests\n"
-            f'  against Server: "{urlparse(serverurl).netloc}"\n'
-            f"  comparing to: {exp.__name__}\n"
-            f"  showact={showact}\n"
-            f"  showcurl={showcurl}\n"
-            f"  client={cls.client}\n"
-        )
         found = cls.client.find(
             constraints={"data_release": ["BOSS-DR16"]}, limit=20
         )
@@ -740,14 +739,21 @@ class AuthTest(unittest.TestCase):
         cls.client = sparcl.client.SparclClient(
             url=serverurl, verbose=clverb, show_curl=showcurl
         )
-        print(
-            f"Running Auth Client Tests\n"
-            f'  against Server: "{urlparse(serverurl).netloc}"\n'
-            f"  comparing to: {exp.__name__}\n"
-            f"  showact={showact}\n"
-            f"  showcurl={showcurl}\n"
-            f"  client={cls.client}\n"
-        )
+
+        global check1
+        global check2
+
+        if check2 is True:
+            print(
+                f"Running Client Tests\n"
+                f'  against Server: "{urlparse(serverurl).netloc}"\n'
+                f"  comparing to: {exp.__name__}\n"
+                f"  showact={showact}\n"
+                f"  showcurl={showcurl}\n"
+                f"  client={cls.client}\n"
+            )
+            check1 = True
+
         cls.outflds = ["sparcl_id", "data_release"]
         cls.inc = ["data_release", "flux"]
 

--- a/tests/tests_api.py
+++ b/tests/tests_api.py
@@ -104,8 +104,7 @@ if showall:
 
 usrpw = os.environ.get("usrpw")
 
-check1 = False
-check2 = True
+show_run_context = True
 
 @contextmanager
 def streamhandler_to_console(lggr):
@@ -169,10 +168,9 @@ class SparclClientTest(unittest.TestCase):
         cls.doc = dict()
         cls.count = dict()
 
-        global check1
-        global check2
+        global show_run_context
 
-        if check1 is False:
+        if show_run_context:
             print(
                 f"Running Client Tests\n"
                 f'  against Server: "{urlparse(serverurl).netloc}"\n'
@@ -181,7 +179,7 @@ class SparclClientTest(unittest.TestCase):
                 f"  showcurl={showcurl}\n"
                 f"  client={cls.client}\n"
             )
-            check2 = False
+            show_run_context = False
 
         # Get some id_lists to use in tests
         found = cls.client.find(
@@ -740,10 +738,9 @@ class AuthTest(unittest.TestCase):
             url=serverurl, verbose=clverb, show_curl=showcurl
         )
 
-        global check1
-        global check2
+        global show_run_context
 
-        if check2 is True:
+        if show_run_context:
             print(
                 f"Running Client Tests\n"
                 f'  against Server: "{urlparse(serverurl).netloc}"\n'
@@ -752,7 +749,7 @@ class AuthTest(unittest.TestCase):
                 f"  showcurl={showcurl}\n"
                 f"  client={cls.client}\n"
             )
-            check1 = True
+            show_run_context = False
 
         cls.outflds = ["sparcl_id", "data_release"]
         cls.inc = ["data_release", "flux"]

--- a/tests/tests_api.py
+++ b/tests/tests_api.py
@@ -7,6 +7,7 @@
 #
 #  ### Run Against DEV Server.
 #  usrpw='' serverurl=http://localhost:8050 python -m unittest tests.tests_api
+#  usrpw='' serverurl=http://sparcdev2.csdc.noirlab.edu:8050 python -m unittest tests.tests_api  # noqa: E501
 #  showact=1 usrpw='' serverurl=http://localhost:8050 python -m unittest tests.tests_api  # noqa: E501
 #
 # python -m unittest  -v tests.tests_api    # VERBOSE (show what is skipped)
@@ -55,6 +56,7 @@ import io
 import numpy
 import logging
 import sys
+import warnings
 
 # Local Packages
 from tests.utils import tic, toc
@@ -182,8 +184,9 @@ class SparclClientTest(unittest.TestCase):
             zip(*[(r["sparcl_id"], r["specid"]) for r in found.records])
         )
         sparc_ids, spec_ids = list(sparc_tups), list(spec_tups)
-        print(f"sparc_ids={sparc_ids}")
-        print(f"spec_ids={spec_ids}")
+        if showact:
+            print(f"sparc_ids={sparc_ids}")
+            print(f"spec_ids={spec_ids}")
 
         # Lists of SPECID
         cls.specid_list0 = spec_ids[:2]
@@ -275,7 +278,7 @@ class SparclClientTest(unittest.TestCase):
         """Specids (not UUID) missing"""
         badid = "NOT_SPEC_ID"
         specids = set([badid] + self.specid_list0[:1])
-        missing = set(self.client.missing_specids(specids, verbose=True))
+        missing = set(self.client.missing_specids(specids, verbose=False))
         if showact:
             print(f"missing_specids_1: specids={specids}")
             print(f"missing_specids_1: missing={missing}")
@@ -472,13 +475,10 @@ class SparclClientTest(unittest.TestCase):
         """Reorder retrieved records by sparcl_id."""
         name = "reorder_1a"
         ids = self.uuid_list2
-        print(f"ids: {ids}")
 
         tic()
         drs = ["SDSS-DR16", "BOSS-DR16", "DESI-EDR"]
         res = self.client.retrieve(ids, dataset_list=drs)
-        res_ids = [r["sparcl_id"] for r in res.records]
-        print(f"retrieved: {res_ids}")
         self.timing[name] = toc()
         res_reorder = res.reorder(ids)
         actual = [f["sparcl_id"] for f in res_reorder.records]
@@ -600,7 +600,7 @@ class SparclClientTest(unittest.TestCase):
             uuid_list=idss,
             include=["ra", "dec"],
             dataset_list=["SDSS-DR16"],
-            verbose=True,
+            verbose=False,
         )
         self.assertEqual(1, re.count)
 
@@ -731,15 +731,6 @@ class AuthTest(unittest.TestCase):
 
         cls.client = sparcl.client.SparclClient(
             url=serverurl, verbose=clverb, show_curl=showcurl
-        )
-
-        print(
-            f"Running Client tests\n"
-            f'  against Server: "{urlparse(serverurl).netloc}"\n'
-            f"  comparing to: {exp.__name__}\n"
-            f"  {showact=}\n"
-            f"  {showcurl=}\n"
-            f"  {cls.client=}\n"
         )
 
         cls.outflds = ["sparcl_id", "data_release"]
@@ -969,12 +960,14 @@ class AuthTest(unittest.TestCase):
     # retrieve from authorized datasets (Public, in this case)
     def test_auth_retrieve_4(self):
         """Retrieve method with unauthorized user; no datasets specified"""
+        warnings.filterwarnings("ignore")
         exp = "exp.auth_retrieve_4"
         self.auth_retrieve(self.unauth_user, None, exp)
 
     # | retrieve | Unauth | Pub | PASS |
     def test_auth_retrieve_5(self):
         """Retrieve method with unauthorized user; public datasets specified"""
+        warnings.filterwarnings("ignore")
         exp = "exp.auth_retrieve_5"
         self.auth_retrieve(self.unauth_user, self.Pub, exp)
 
@@ -991,11 +984,13 @@ class AuthTest(unittest.TestCase):
     # retrieve from authorized datasets (Public, in this case)
     def test_auth_retrieve_7(self):
         """Retrieve method with anonymous user; no data sets specified"""
+        warnings.filterwarnings("ignore")
         exp = "exp.auth_retrieve_7"
         self.auth_retrieve(None, None, exp)
 
     # | retrieve | Anon | Pub | PASS |
     def test_auth_retrieve_8(self):
         """Retrieve method with anonymous user; public data sets specified"""
+        warnings.filterwarnings("ignore")
         exp = "exp.auth_retrieve_8"
         self.auth_retrieve(None, self.Pub, exp)


### PR DESCRIPTION
In this PR:
- Remove free-floating print statements (i.e. those that don't use `if showact`)
- Set `verbose=False` for statements that had previously explicitly set `verbose=True`

All 64 tests pass against sparcdev2 and sparc1 (with VPN on). Output now looks like this for sparcdev2:
```
Arranging to run doctests against: sparcl.client
Arranging to run doctests against: sparcl.gather_2d
sssssss.................sRunning Client tests
  against Server: "sparcdev2.csdc.noirlab.edu:8050"
  comparing to: tests.expected_pat
  showact=False
  showcurl=False
  client=(sparclclient:1.2.2b8, api:11.0, http://sparcdev2.csdc.noirlab.edu:8050/sparc, client_hash=, verbose=False, connect_timeout=1.1, read_timeout=5400.0)

...s..sss..............................
----------------------------------------------------------------------
Ran 64 tests in 72.902s

OK (skipped=12)
```

And this for sparc1:
```
Arranging to run doctests against: sparcl.client
Arranging to run doctests against: sparcl.gather_2d
sssssss.................sRunning Client tests
  against Server: "sparc1.datalab.noirlab.edu"
  comparing to: tests.expected_pat
  showact=False
  showcurl=False
  client=(sparclclient:1.2.2b8, api:11.0, https://sparc1.datalab.noirlab.edu/sparc, client_hash=, verbose=False, connect_timeout=1.1, read_timeout=5400.0)

...s..sss..............................
----------------------------------------------------------------------
Ran 64 tests in 79.100s

OK (skipped=12)
```