### PR TITLE
exclude UNPUBLISHED and add test for SSO

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,9 @@ dynamic = ["version", "description"]
 [tool.flit.module]
 name = "sparcl"
 
+[tool.flit.sdist]
+exclude = ["**/UNPUBLISHED/", "**/OBSOLETE/"]
+
 [tool.black]
 # https://black.readthedocs.io/en/stable/usage_and_configuration/index.html
 line-length = 79

--- a/sparcl/__init__.py
+++ b/sparcl/__init__.py
@@ -31,4 +31,4 @@ __all__ = ["client", "align_records"]
 # __version__ = "1.2.1b3"
 # __version__ = "1.2.1"
 # FIRST uncommented value will be used! (so only leave one uncommented)
-__version__ = "1.2.2b8"
+__version__ = "1.2.2b9"

--- a/sparcl/client.py
+++ b/sparcl/client.py
@@ -658,7 +658,7 @@ class SparclClient:  # was SparclApi()
             are NOT stored in the SPARCL database.
 
         Example:
-            >>> client = SparclClient(url=_DEV)
+            >>> client = SparclClient()
             >>> found = client.find(outfields=['specid'], limit=2)
             >>> specids = [f.specid for f in found.records]
             >>> client.missing_specids(specids + ['bad_id'])

--- a/sparcl/client.py
+++ b/sparcl/client.py
@@ -658,7 +658,7 @@ class SparclClient:  # was SparclApi()
             are NOT stored in the SPARCL database.
 
         Example:
-            >>> client = SparclClient(url=_PAT)
+            >>> client = SparclClient(url=_DEV)
             >>> found = client.find(outfields=['specid'], limit=2)
             >>> specids = [f.specid for f in found.records]
             >>> client.missing_specids(specids + ['bad_id'])

--- a/tests/tests_api.py
+++ b/tests/tests_api.py
@@ -135,11 +135,18 @@ def testcase_log_console(lggr):
 def load_tests(loader, tests, ignore):
     import doctest
 
-    print(f"Arranging to run doctests against: sparcl.client")
-    tests.addTests(doctest.DocTestSuite(sparcl.client))
+    if serverurl == _PROD:
+        print(f"Arranging to run doctests against: sparcl.client")
+        tests.addTests(doctest.DocTestSuite(sparcl.client))
 
-    print(f"Arranging to run doctests against: sparcl.gather_2d")
-    tests.addTests(doctest.DocTestSuite(sparcl.gather_2d))
+        print(f"Arranging to run doctests against: sparcl.gather_2d")
+        tests.addTests(doctest.DocTestSuite(sparcl.gather_2d))
+    else:
+        print(
+            "Not running doctests since you are not running client"
+            " against the PRODUCTION server."
+        )
+
     return tests
 
 

--- a/tests/tests_api.py
+++ b/tests/tests_api.py
@@ -843,19 +843,25 @@ class AuthTest(unittest.TestCase):
     # certificate verify failed: unable to get local issuer certificate
     # (_ssl.c:997)')))
 
+    def test_sso_server(self):
+        sso_server = "https://sso.csdc.noirlab.edu/"
+        response = requests.get(sso_server)
+        self.assertEqual(response.status_code, 200, response.content.decode())
+
     def test_get_token(self):
         """Make sure we can get expected SSO token."""
         json = {"email": self.auth_user, "password": usrpw}
         if showact:
             print(f"test_get_token: {json=}")
 
-        expected = ""
+        expected = 281
         res = requests.post(f"{self.client.apiurl}/get_token/", json=json)
         self.assertEqual(res.status_code, 200, res.content.decode())
-
+        token = res.content.decode()
+        actual = len(token)
         if showact:
-            print(f"test_get_token: {res=}")
-        self.assertEqual(res, expected, msg="Actual to Expected")
+            print(f"test_get_token: ({len(token)}) {token=!s}")
+        self.assertEqual(actual, expected, msg="Actual to Expected")
 
     def test_authorized_1(self):
         """Test authorized method with authorized user signed in"""


### PR DESCRIPTION
Deploy to PyPi should exclude notebooks/UNPLUBLISHED/ directory so that something like `pip install sparclclient==1.2.2b9`  will not install the UNBPUBLISHED directory.  That dir is intended to contain notebooks we find useful but are not appropriate for general user.  NOTE: the directory content will still be available via the repo so it should be ok for anyone to see it; just not useful.

This also adds test_get_token.  The test will fail with appropriate message output when (for instance) SSO has bad CERTS and does not work.