### PR TITLE
Update expected auth values for client tests

### DIFF
--- a/tests/expected_pat.py
+++ b/tests/expected_pat.py
@@ -100,11 +100,22 @@ priv = ["SDSS-DR17-test"]
 unauth = "test_user_2@noirlab.edu"
 #
 auth_find_1 = auth_find_2 = pub_all + priv
-auth_find_3 = f"[DSDENIED] {unauth} is declined access to datasets {priv}"
+# OLD as of July 9, 2024
+#auth_find_3 = f"[DSDENIED] {unauth} is declined access to datasets {priv}"
+auth_find_3 = auth_retrieve_3 = (f"[DSDENIED] uname='{unauth}' is declined "
+                                 f"access to datasets={priv}; "
+                                 f"drs_requested={pub_all + priv} "
+                                 f"my_auth={pub_all}")
 auth_find_4 = auth_find_6 = pub_all
-auth_find_5 = f"[DSDENIED] ANONYMOUS is declined access to datasets {priv}"
-#
+# OLD as of July 9, 2024
+#auth_find_5 = f"[DSDENIED] ANONYMOUS is declined access to datasets {priv}"
+auth_find_5 = auth_retrieve_6 = ("[DSDENIED] uname='ANONYMOUS' is declined "
+                                 f"access to datasets={priv}; "
+                                 f"drs_requested={pub_all + priv} "
+                                 f"my_auth={pub_all}")
 auth_retrieve_1 = auth_retrieve_2 = pub_1 + priv
-auth_retrieve_3 = f"[DSDENIED] {unauth} is declined access to datasets {priv}"
+# OLD as of July 9, 2024
+#auth_retrieve_3 = f"[DSDENIED] {unauth} is declined access to datasets {priv}"
 auth_retrieve_4 = auth_retrieve_5 = auth_retrieve_7 = auth_retrieve_8 = pub_1
-auth_retrieve_6 = f"[DSDENIED] ANONYMOUS is declined access to datasets {priv}"
+# OLD as of July 9, 2024
+#auth_retrieve_6 = f"[DSDENIED] ANONYMOUS is declined access to datasets {priv}"  # noqa: E501


### PR DESCRIPTION
Updates the expected values from tests for when an unauthorized user tries to access a private dataset. 

Before running tests, rebuild the Server database using `init-db.sh`. 

All client tests pass on sparcdev2 as devops in /home/ajacques/sparclclient:
```
(venv) [devops@sparcdev2 sparclclient]$ usrpw='<passwordhere>' serverurl=http://sparcdev2.csdc.noirlab.edu:8050 python -m unittest tests.tests_api
Not running doctests since you are not running client against the PRODUCTION server.
sssssss
    Running Client Tests
      against Server:   "sparcdev2.csdc.noirlab.edu:8050"
      comparing to:     tests.expected_pat
      showact=False
      showcurl=False
      client=(sparclclient:1.2.2b10, api:12.0, http://sparcdev2.csdc.noirlab.edu:8050/sparc, client_hash=, verbose=False, connect_timeout=1.1, read_timeout=5400.0)

    For REPRODUCIBLE RESULTS rebuild Server DB before running tests!
    Use: init-db.sh

...................s..ss..sss..................
----------------------------------------------------------------------
Ran 54 tests in 12.479s

OK (skipped=13)
```

flake8 also passes (on modified files in this PR)